### PR TITLE
Set commit date to epoch in SLSA builder

### DIFF
--- a/.github/workflows/slsa-goreleaser.yaml
+++ b/.github/workflows/slsa-goreleaser.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "version=$(git describe --tags --always --dirty | cut -c2-)" >> "$GITHUB_OUTPUT"
           echo "commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
+          echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
           echo "tree-state=$(if git diff --quiet; then echo "clean"; else echo "dirty"; fi)" >> "$GITHUB_OUTPUT"
 
   build:


### PR DESCRIPTION
Otherwise the builder complains:

> invalid env argument: COMMIT_DATE:2024-05-31T18:56:56+02:00

See https://github.com/norbjd/kueueleuleu/actions/runs/9321639903/job/25661098584.