### PR TITLE
fix(e2e): update k8s versions, tekton and use cowsay

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,10 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - v1.26.x
-          - v1.27.x
-          - v1.28.x
-          - v1.29.x
+          - v1.32.x
+          - v1.33.x
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/cmd/kueueleuleu/testdata/cronjob_output.yaml
+++ b/cmd/kueueleuleu/testdata/cronjob_output.yaml
@@ -108,7 +108,7 @@ spec:
             - init
             - /ko-app/entrypoint
             - /tekton/bin/entrypoint
-            image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
+            image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
             name: kueueleuleu-prepare
             resources: {}
             volumeMounts:

--- a/cmd/kueueleuleu/testdata/cronjob_output.yaml
+++ b/cmd/kueueleuleu/testdata/cronjob_output.yaml
@@ -108,7 +108,7 @@ spec:
             - init
             - /ko-app/entrypoint
             - /tekton/bin/entrypoint
-            image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
+            image: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1
             name: kueueleuleu-prepare
             resources: {}
             volumeMounts:

--- a/cmd/kueueleuleu/testdata/cronjob_output.yaml
+++ b/cmd/kueueleuleu/testdata/cronjob_output.yaml
@@ -108,7 +108,7 @@ spec:
             - init
             - /ko-app/entrypoint
             - /tekton/bin/entrypoint
-            image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32
+            image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
             name: kueueleuleu-prepare
             resources: {}
             volumeMounts:

--- a/cmd/kueueleuleu/testdata/job_output.yaml
+++ b/cmd/kueueleuleu/testdata/job_output.yaml
@@ -102,7 +102,7 @@ spec:
         - init
         - /ko-app/entrypoint
         - /tekton/bin/entrypoint
-        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
+        image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
         name: kueueleuleu-prepare
         resources: {}
         volumeMounts:

--- a/cmd/kueueleuleu/testdata/job_output.yaml
+++ b/cmd/kueueleuleu/testdata/job_output.yaml
@@ -102,7 +102,7 @@ spec:
         - init
         - /ko-app/entrypoint
         - /tekton/bin/entrypoint
-        image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
+        image: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1
         name: kueueleuleu-prepare
         resources: {}
         volumeMounts:

--- a/cmd/kueueleuleu/testdata/job_output.yaml
+++ b/cmd/kueueleuleu/testdata/job_output.yaml
@@ -102,7 +102,7 @@ spec:
         - init
         - /ko-app/entrypoint
         - /tekton/bin/entrypoint
-        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
         name: kueueleuleu-prepare
         resources: {}
         volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
+    image: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:
@@ -224,7 +224,7 @@ spec:
         - init
         - /ko-app/entrypoint
         - /tekton/bin/entrypoint
-        image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
+        image: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1
         name: kueueleuleu-prepare
         resources: {}
         volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:v1.3.1
+    image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_and_job_output.yaml
@@ -224,7 +224,7 @@ spec:
         - init
         - /ko-app/entrypoint
         - /tekton/bin/entrypoint
-        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32
+        image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
         name: kueueleuleu-prepare
         resources: {}
         volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
+    image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1
+    image: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:

--- a/cmd/kueueleuleu/testdata/pod_output.yaml
+++ b/cmd/kueueleuleu/testdata/pod_output.yaml
@@ -96,7 +96,7 @@ spec:
     - init
     - /ko-app/entrypoint
     - /tekton/bin/entrypoint
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1
     name: kueueleuleu-prepare
     resources: {}
     volumeMounts:

--- a/convert_e2e_test.go
+++ b/convert_e2e_test.go
@@ -105,14 +105,14 @@ var podSpecCowsayInvalid = corev1.PodSpec{
 	RestartPolicy: "Never",
 }
 
-var cowsay = ` _______
+var cowsay = ` _
 <   >
- -------
+ -
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\
                 ||----w |
-                ||     ||  
+                ||     ||
 `
 
 var debug bool

--- a/convert_e2e_test.go
+++ b/convert_e2e_test.go
@@ -74,13 +74,13 @@ var podSpecWhalesayValid = corev1.PodSpec{
 	Containers: []corev1.Container{
 		{
 			Name:    "say-hello",
-			Image:   "docker/whalesay",
+			Image:   "docker/whalesay:latest",
 			Command: []string{"cowsay"},
 			Args:    []string{"hello"},
 		},
 		{
 			Name:    "say-nothing",
-			Image:   "docker/whalesay",
+			Image:   "docker/whalesay:latest",
 			Command: []string{"cowsay"},
 		},
 	},
@@ -91,7 +91,7 @@ var podSpecWhalesayInvalid = corev1.PodSpec{
 	Containers: []corev1.Container{
 		{
 			Name:    "say-hello",
-			Image:   "docker/whalesay",
+			Image:   "docker/whalesay:latest",
 			Command: []string{"cowsay"},
 			Args:    []string{"hello"},
 		},

--- a/convert_e2e_test.go
+++ b/convert_e2e_test.go
@@ -70,34 +70,34 @@ var podSpecSleep = corev1.PodSpec{
 	RestartPolicy: "Never",
 }
 
-var podSpecWhalesayValid = corev1.PodSpec{
+var podSpecCowsayValid = corev1.PodSpec{
 	Containers: []corev1.Container{
 		{
 			Name:    "say-hello",
-			Image:   "docker/whalesay:latest",
+			Image:   "rancher/cowsay:latest",
 			Command: []string{"cowsay"},
 			Args:    []string{"hello"},
 		},
 		{
 			Name:    "say-nothing",
-			Image:   "docker/whalesay:latest",
+			Image:   "rancher/cowsay:latest",
 			Command: []string{"cowsay"},
 		},
 	},
 	RestartPolicy: "Never",
 }
 
-var podSpecWhalesayInvalid = corev1.PodSpec{
+var podSpecCowsayInvalid = corev1.PodSpec{
 	Containers: []corev1.Container{
 		{
 			Name:    "say-hello",
-			Image:   "docker/whalesay:latest",
+			Image:   "rancher/cowsay:latest",
 			Command: []string{"cowsay"},
 			Args:    []string{"hello"},
 		},
 		{
 			Name:  "say-goodbye",
-			Image: "docker/whalesay:latest",
+			Image: "rancher/cowsay:latest",
 			// here, Command is not set, so kueueleuleu should return an error
 			Args: []string{"goodbye"},
 		},
@@ -105,20 +105,14 @@ var podSpecWhalesayInvalid = corev1.PodSpec{
 	RestartPolicy: "Never",
 }
 
-var whalesay = ` _ 
+var cowsay = ` _______
 <   >
- - 
-    \
-     \
-      \     
-                    ##        .            
-              ## ## ##       ==            
-           ## ## ## ##      ===            
-       /""""""""""""""""___/ ===        
-  ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~   
-       \______ o          __/            
-        \    \        __/             
-          \____\______/   
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||  
 `
 
 var debug bool
@@ -246,14 +240,14 @@ func Test_CreatePodSleep(t *testing.T) {
 	assert.GreaterOrEqual(t, step3Sleep20Duration, 20*time.Second)
 }
 
-func Test_CreatePodWhalesayValid(t *testing.T) {
+func Test_CreatePodCowsayValid(t *testing.T) {
 	t.Parallel()
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("whalesay-%s", uuid.NewUUID()),
+			Name: fmt.Sprintf("cowsay-%s", uuid.NewUUID()),
 		},
-		Spec: podSpecWhalesayValid,
+		Spec: podSpecCowsayValid,
 	}
 
 	kueueleuleuPod, err := kueueleuleu.ConvertPod(pod)
@@ -299,17 +293,17 @@ func Test_CreatePodWhalesayValid(t *testing.T) {
 	logs, err := io.ReadAll(podLogs)
 	require.NoError(t, err)
 
-	assert.Equal(t, whalesay, string(logs))
+	assert.Equal(t, cowsay, string(logs))
 }
 
-func Test_CreatePodWhalesayInvalid(t *testing.T) {
+func Test_CreatePodCowsayInvalid(t *testing.T) {
 	t.Parallel()
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("whalesay-%s", uuid.NewUUID()),
+			Name: fmt.Sprintf("cowsay-%s", uuid.NewUUID()),
 		},
-		Spec: podSpecWhalesayInvalid,
+		Spec: podSpecCowsayInvalid,
 	}
 
 	_, err := kueueleuleu.ConvertPod(pod)

--- a/convert_e2e_test.go
+++ b/convert_e2e_test.go
@@ -97,7 +97,7 @@ var podSpecWhalesayInvalid = corev1.PodSpec{
 		},
 		{
 			Name:  "say-goodbye",
-			Image: "docker/whalesay",
+			Image: "docker/whalesay:latest",
 			// here, Command is not set, so kueueleuleu should return an error
 			Args: []string{"goodbye"},
 		},

--- a/convert_e2e_test.go
+++ b/convert_e2e_test.go
@@ -105,9 +105,9 @@ var podSpecCowsayInvalid = corev1.PodSpec{
 	RestartPolicy: "Never",
 }
 
-var cowsay = ` _
+var cowsay = ` _ 
 <   >
- -
+ - 
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\

--- a/internal_convert.go
+++ b/internal_convert.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	prepareInitContainerName = "kueueleuleu-prepare"
-	tektonEntrypointImage    = "ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1"
+	tektonEntrypointImage    = "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.3.1"
 
 	kueueleuleuAnnotationKey   = "norbjd.github.io/kueueleuleu"
 	kueueleuleuAnnotationValue = "true"

--- a/internal_convert.go
+++ b/internal_convert.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	prepareInitContainerName = "kueueleuleu-prepare"
-	tektonEntrypointImage    = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1"
+	tektonEntrypointImage    = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1"
 
 	kueueleuleuAnnotationKey   = "norbjd.github.io/kueueleuleu"
 	kueueleuleuAnnotationValue = "true"

--- a/internal_convert.go
+++ b/internal_convert.go
@@ -27,8 +27,7 @@ import (
 
 const (
 	prepareInitContainerName = "kueueleuleu-prepare"
-	tektonEntrypointImage    = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint" +
-		"@sha256:40abc3a78b558f251e890085972ed25fe7ad428f47998bc9c9c18f564dc03c32"
+	tektonEntrypointImage    = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint@v1.3.1"
 
 	kueueleuleuAnnotationKey   = "norbjd.github.io/kueueleuleu"
 	kueueleuleuAnnotationValue = "true"

--- a/internal_convert.go
+++ b/internal_convert.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	prepareInitContainerName = "kueueleuleu-prepare"
-	tektonEntrypointImage    = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1"
+	tektonEntrypointImage    = "ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/entrypoint:v1.3.1"
 
 	kueueleuleuAnnotationKey   = "norbjd.github.io/kueueleuleu"
 	kueueleuleuAnnotationValue = "true"


### PR DESCRIPTION
Fix e2e tests.

1. no need to tests a lot of k8s versions, and especially if they are old. Older versions are not available for `setup-kind` action anymore (see https://github.com/chainguard-dev/actions/blob/b1933e3d1f574c772dc7efd68c2060dafbc25e8c/setup-kind/action.yaml#L108-L126), so CI is failing
2. current Tekton image is also outdated, and images have been moved to ghcr.io, see https://tekton.dev/blog/2025/04/03/migration-to-github-container-registry/
3. finally, `docker/whalesay` image is deprecated (`Failed to pull image "docker/whalesay": [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release.`), so use `rancher/cowsay` instead